### PR TITLE
Fix missing import of `OrderedDict` from collections.

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -22,8 +22,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-from collections import OrderedDict
 from __future__ import absolute_import, unicode_literals, print_function
+from collections import OrderedDict
 
 import io
 import os

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -22,6 +22,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+from collections import OrderedDict
 from __future__ import absolute_import, unicode_literals, print_function
 
 import io

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -23,8 +23,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-from collections import OrderedDict
 from __future__ import absolute_import, unicode_literals, print_function
+from collections import OrderedDict
 
 import os
 import sys

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -23,6 +23,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+from collections import OrderedDict
 from __future__ import absolute_import, unicode_literals, print_function
 
 import os


### PR DESCRIPTION
There already two forks that have introduced the same commits that resolve this bug.
Id suggest merging these back to the original repository.
